### PR TITLE
docs(readme): change folder expression "dist" to "dist/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ You may have some build script in your package.json involving mirroring folders 
     "copy-and-watch": "latest"
   },
   "scripts": {
-    "build": "copy-and-watch src/**/*.{html,json} src/**/fonts/* dist",
-    "watch": "copy-and-watch --watch src/**/*.{html,json} src/**/{fonts,images}/* dist"
+    "build": "copy-and-watch src/**/*.{html,json} src/**/fonts/* dist/",
+    "watch": "copy-and-watch --watch src/**/*.{html,json} src/**/{fonts,images}/* dist/"
   }
 }
 ```


### PR DESCRIPTION
If user uses "dist" instead of "dist/", when the folder already exists, it fails with error "mkdir folder already exists".
Plus "dist/" signals that it is a folder, so it's more correct than "dist" anyways.